### PR TITLE
feat: implement HTTP error handling with structured responses

### DIFF
--- a/pkg/error/.cursor/rules/http.mdc
+++ b/pkg/error/.cursor/rules/http.mdc
@@ -1,0 +1,66 @@
+# HTTP Error Handling Specification
+
+## Goals
+- Provide **structured errors** for HTTP responses with fields:
+  - `StatusCode` (int): HTTP status code (e.g., 404, 500)
+  - `Code` (string): Machine-readable error code (e.g., `not_found`)
+  - `Message` (string): Human-readable error message.
+- Preserve **stack trace information** for unexpected or unhandled errors.
+- Separate **business errors** (controlled errors) from **internal errors** (traceable).
+
+---
+
+## Error Types
+
+### HTTPError
+- Represents controlled errors that map directly to an HTTP response.
+- Should be used for validation errors, not found errors, unauthorized, etc.
+- Does **not** contain stack trace.
+
+**Fields:**
+- `StatusCode int`
+- `Code string`
+- `Message string`
+
+**Example:**
+```go
+var ErrNotFound = &HTTPError{
+    StatusCode: 404,
+    Code:       "not_found",
+    Message:    "Data not found",
+}
+
+```
+
+**Methods:**
+```go
+// Error implements the error interface
+func (e *HTTPError) Error() string
+
+// GetStatusCode returns the HTTP status code
+func (e *HTTPError) GetStatusCode() int
+
+// GetCode returns the machine-readable error code
+func (e *HTTPError) GetCode() string
+```
+
+**Constructors:**
+```go
+// NewHTTPError creates a new HTTPError with the given parameters
+func NewHTTPError(statusCode int, code, message string) *HTTPError
+
+// NewNotFoundError creates a 404 Not Found error
+func NewNotFoundError(message string) *HTTPError
+
+// NewValidationError creates a 400 Bad Request validation error
+func NewValidationError(message string) *HTTPError
+
+// NewUnauthorizedError creates a 401 Unauthorized error
+func NewUnauthorizedError(message string) *HTTPError
+
+// NewForbiddenError creates a 403 Forbidden error
+func NewForbiddenError(message string) *HTTPError
+
+// NewInternalServerError creates a 500 Internal Server Error
+func NewInternalServerError(message string) *HTTPError
+```

--- a/pkg/error/http.go
+++ b/pkg/error/http.go
@@ -1,0 +1,66 @@
+package error
+
+// HTTPError represents controlled errors that map directly to an HTTP response.
+// Should be used for validation errors, not found errors, unauthorized, etc.
+// Does not contain stack trace.
+type HTTPError struct {
+	StatusCode int    `json:"status_code"`
+	Code       string `json:"code"`
+	Message    string `json:"message"`
+}
+
+// Error implements the error interface
+func (e *HTTPError) Error() string {
+	return e.Message
+}
+
+// GetStatusCode returns the HTTP status code
+func (e *HTTPError) GetStatusCode() int {
+	return e.StatusCode
+}
+
+// GetCode returns the machine-readable error code
+func (e *HTTPError) GetCode() string {
+	return e.Code
+}
+
+// NewHTTPError creates a new HTTPError with the given parameters
+func NewHTTPError(statusCode int, code, message string) *HTTPError {
+	return &HTTPError{
+		StatusCode: statusCode,
+		Code:       code,
+		Message:    message,
+	}
+}
+
+// NewNotFoundError creates a 404 Not Found error
+func NewNotFoundError(message string) *HTTPError {
+	return NewHTTPError(404, "not_found", message)
+}
+
+// NewValidationError creates a 400 Bad Request validation error
+func NewValidationError(message string) *HTTPError {
+	return NewHTTPError(400, "validation_error", message)
+}
+
+// NewUnauthorizedError creates a 401 Unauthorized error
+func NewUnauthorizedError(message string) *HTTPError {
+	return NewHTTPError(401, "unauthorized", message)
+}
+
+// NewForbiddenError creates a 403 Forbidden error
+func NewForbiddenError(message string) *HTTPError {
+	return NewHTTPError(403, "forbidden", message)
+}
+
+// NewInternalServerError creates a 500 Internal Server Error
+func NewInternalServerError(message string) *HTTPError {
+	return NewHTTPError(500, "internal_server_error", message)
+}
+
+// Common error instances for reuse
+var (
+	ErrNotFound     = NewNotFoundError("Data not found")
+	ErrUnauthorized = NewUnauthorizedError("Unauthorized access")
+	ErrForbidden    = NewForbiddenError("Access forbidden")
+)

--- a/pkg/error/http_test.go
+++ b/pkg/error/http_test.go
@@ -1,0 +1,324 @@
+package error_test
+
+import (
+	"testing"
+
+	"github.com/harungurubudi/mtsg/pkg/error"
+	"github.com/stretchr/testify/suite"
+)
+
+type HTTPErrorTestSuite struct {
+	suite.Suite
+}
+
+func TestHTTPErrorTestSuite(t *testing.T) {
+	suite.Run(t, new(HTTPErrorTestSuite))
+}
+
+func (suite *HTTPErrorTestSuite) TestHTTPError_Error() {
+	tests := []struct {
+		name     string
+		httpErr  *error.HTTPError
+		expected string
+	}{
+		{
+			name: "ShouldReturnMessage",
+			httpErr: &error.HTTPError{
+				StatusCode: 404,
+				Code:       "not_found",
+				Message:    "Resource not found",
+			},
+			expected: "Resource not found",
+		},
+		{
+			name: "ShouldReturnEmptyMessage",
+			httpErr: &error.HTTPError{
+				StatusCode: 500,
+				Code:       "internal_error",
+				Message:    "",
+			},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		suite.Run(tt.name, func() {
+			result := tt.httpErr.Error()
+			suite.Equal(tt.expected, result)
+		})
+	}
+}
+
+func (suite *HTTPErrorTestSuite) TestHTTPError_GetStatusCode() {
+	tests := []struct {
+		name     string
+		httpErr  *error.HTTPError
+		expected int
+	}{
+		{
+			name: "ShouldReturn404",
+			httpErr: &error.HTTPError{
+				StatusCode: 404,
+				Code:       "not_found",
+				Message:    "Not found",
+			},
+			expected: 404,
+		},
+		{
+			name: "ShouldReturn500",
+			httpErr: &error.HTTPError{
+				StatusCode: 500,
+				Code:       "internal_error",
+				Message:    "Internal error",
+			},
+			expected: 500,
+		},
+	}
+
+	for _, tt := range tests {
+		suite.Run(tt.name, func() {
+			result := tt.httpErr.GetStatusCode()
+			suite.Equal(tt.expected, result)
+		})
+	}
+}
+
+func (suite *HTTPErrorTestSuite) TestHTTPError_GetCode() {
+	tests := []struct {
+		name     string
+		httpErr  *error.HTTPError
+		expected string
+	}{
+		{
+			name: "ShouldReturnNotFoundCode",
+			httpErr: &error.HTTPError{
+				StatusCode: 404,
+				Code:       "not_found",
+				Message:    "Not found",
+			},
+			expected: "not_found",
+		},
+		{
+			name: "ShouldReturnValidationCode",
+			httpErr: &error.HTTPError{
+				StatusCode: 400,
+				Code:       "validation_error",
+				Message:    "Validation failed",
+			},
+			expected: "validation_error",
+		},
+	}
+
+	for _, tt := range tests {
+		suite.Run(tt.name, func() {
+			result := tt.httpErr.GetCode()
+			suite.Equal(tt.expected, result)
+		})
+	}
+}
+
+func (suite *HTTPErrorTestSuite) TestNewHTTPError() {
+	tests := []struct {
+		name       string
+		statusCode int
+		code       string
+		message    string
+		expected   *error.HTTPError
+	}{
+		{
+			name:       "ShouldCreateNotFoundError",
+			statusCode: 404,
+			code:       "not_found",
+			message:    "Resource not found",
+			expected: &error.HTTPError{
+				StatusCode: 404,
+				Code:       "not_found",
+				Message:    "Resource not found",
+			},
+		},
+		{
+			name:       "ShouldCreateValidationError",
+			statusCode: 400,
+			code:       "validation_error",
+			message:    "Invalid input",
+			expected: &error.HTTPError{
+				StatusCode: 400,
+				Code:       "validation_error",
+				Message:    "Invalid input",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		suite.Run(tt.name, func() {
+			result := error.NewHTTPError(tt.statusCode, tt.code, tt.message)
+			suite.Equal(tt.expected.StatusCode, result.StatusCode)
+			suite.Equal(tt.expected.Code, result.Code)
+			suite.Equal(tt.expected.Message, result.Message)
+		})
+	}
+}
+
+func (suite *HTTPErrorTestSuite) TestNewNotFoundError() {
+	tests := []struct {
+		name     string
+		message  string
+		expected *error.HTTPError
+	}{
+		{
+			name:    "ShouldCreateNotFoundError",
+			message: "User not found",
+			expected: &error.HTTPError{
+				StatusCode: 404,
+				Code:       "not_found",
+				Message:    "User not found",
+			},
+		},
+		{
+			name:    "ShouldCreateNotFoundErrorWithEmptyMessage",
+			message: "",
+			expected: &error.HTTPError{
+				StatusCode: 404,
+				Code:       "not_found",
+				Message:    "",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		suite.Run(tt.name, func() {
+			result := error.NewNotFoundError(tt.message)
+			suite.Equal(tt.expected.StatusCode, result.StatusCode)
+			suite.Equal(tt.expected.Code, result.Code)
+			suite.Equal(tt.expected.Message, result.Message)
+		})
+	}
+}
+
+func (suite *HTTPErrorTestSuite) TestNewValidationError() {
+	tests := []struct {
+		name     string
+		message  string
+		expected *error.HTTPError
+	}{
+		{
+			name:    "ShouldCreateValidationError",
+			message: "Email is required",
+			expected: &error.HTTPError{
+				StatusCode: 400,
+				Code:       "validation_error",
+				Message:    "Email is required",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		suite.Run(tt.name, func() {
+			result := error.NewValidationError(tt.message)
+			suite.Equal(tt.expected.StatusCode, result.StatusCode)
+			suite.Equal(tt.expected.Code, result.Code)
+			suite.Equal(tt.expected.Message, result.Message)
+		})
+	}
+}
+
+func (suite *HTTPErrorTestSuite) TestNewUnauthorizedError() {
+	tests := []struct {
+		name     string
+		message  string
+		expected *error.HTTPError
+	}{
+		{
+			name:    "ShouldCreateUnauthorizedError",
+			message: "Invalid credentials",
+			expected: &error.HTTPError{
+				StatusCode: 401,
+				Code:       "unauthorized",
+				Message:    "Invalid credentials",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		suite.Run(tt.name, func() {
+			result := error.NewUnauthorizedError(tt.message)
+			suite.Equal(tt.expected.StatusCode, result.StatusCode)
+			suite.Equal(tt.expected.Code, result.Code)
+			suite.Equal(tt.expected.Message, result.Message)
+		})
+	}
+}
+
+func (suite *HTTPErrorTestSuite) TestNewForbiddenError() {
+	tests := []struct {
+		name     string
+		message  string
+		expected *error.HTTPError
+	}{
+		{
+			name:    "ShouldCreateForbiddenError",
+			message: "Access denied",
+			expected: &error.HTTPError{
+				StatusCode: 403,
+				Code:       "forbidden",
+				Message:    "Access denied",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		suite.Run(tt.name, func() {
+			result := error.NewForbiddenError(tt.message)
+			suite.Equal(tt.expected.StatusCode, result.StatusCode)
+			suite.Equal(tt.expected.Code, result.Code)
+			suite.Equal(tt.expected.Message, result.Message)
+		})
+	}
+}
+
+func (suite *HTTPErrorTestSuite) TestNewInternalServerError() {
+	tests := []struct {
+		name     string
+		message  string
+		expected *error.HTTPError
+	}{
+		{
+			name:    "ShouldCreateInternalServerError",
+			message: "Something went wrong",
+			expected: &error.HTTPError{
+				StatusCode: 500,
+				Code:       "internal_server_error",
+				Message:    "Something went wrong",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		suite.Run(tt.name, func() {
+			result := error.NewInternalServerError(tt.message)
+			suite.Equal(tt.expected.StatusCode, result.StatusCode)
+			suite.Equal(tt.expected.Code, result.Code)
+			suite.Equal(tt.expected.Message, result.Message)
+		})
+	}
+}
+
+func (suite *HTTPErrorTestSuite) TestCommonErrorInstances() {
+	suite.Run("ShouldHaveCorrectErrNotFound", func() {
+		suite.Equal(404, error.ErrNotFound.GetStatusCode())
+		suite.Equal("not_found", error.ErrNotFound.GetCode())
+		suite.Equal("Data not found", error.ErrNotFound.Error())
+	})
+
+	suite.Run("ShouldHaveCorrectErrUnauthorized", func() {
+		suite.Equal(401, error.ErrUnauthorized.GetStatusCode())
+		suite.Equal("unauthorized", error.ErrUnauthorized.GetCode())
+		suite.Equal("Unauthorized access", error.ErrUnauthorized.Error())
+	})
+
+	suite.Run("ShouldHaveCorrectErrForbidden", func() {
+		suite.Equal(403, error.ErrForbidden.GetStatusCode())
+		suite.Equal("forbidden", error.ErrForbidden.GetCode())
+		suite.Equal("Access forbidden", error.ErrForbidden.Error())
+	})
+}


### PR DESCRIPTION
- Add HTTPError struct with StatusCode, Code, and Message fields
- Implement Error(), GetStatusCode(), and GetCode() methods
- Add constructor functions for common HTTP error types:
  - NewHTTPError() for custom errors
  - NewNotFoundError() for 404 errors
  - NewValidationError() for 400 errors
  - NewUnauthorizedError() for 401 errors
  - NewForbiddenError() for 403 errors
  - NewInternalServerError() for 500 errors
- Provide common error instances: ErrNotFound, ErrUnauthorized, ErrForbidden
- Add comprehensive unit tests with table-driven test cases
- Support JSON serialization with snake_case field names
- Separate controlled HTTP errors from internal traceable errors

This enables consistent, structured error responses across the API layer while maintaining clean separation between business and internal errors.